### PR TITLE
Updated to latest jbcrypt version 0.4.1.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.mindrot/jbcrypt "0.3m"]])
+                 [de.svenkubiak/jBCrypt "0.4.1"]])


### PR DESCRIPTION
**Justification**
This 0.3m version of the jbcrypt contains a known vulnerability.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0886

This causes problems with security audits for applications that use this wrapper.

**PR Details**
I have updated project.clj and executed the unit tests.  I have also overridden the transitive dependency in our applications and everything works as expected.
